### PR TITLE
byebug setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# Hide `byebug` history
+.byebug_history

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.1)
     diff-lcs (1.3)
     rake (12.3.3)
     rspec (3.9.0)
@@ -27,6 +28,7 @@ PLATFORMS
 
 DEPENDENCIES
   basic_temperature!
+  byebug (~> 11.1)
   rake (~> 12.0)
   rspec (~> 3.0)
 

--- a/basic_temperature.gemspec
+++ b/basic_temperature.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.require_paths = ["lib"]
+
+  spec.add_development_dependency 'byebug', '~> 11.1'
 end


### PR DESCRIPTION
- Setup [`byebug`](https://github.com/deivid-rodriguez/byebug) as a development dependency.
- Add `.byebug_history` to `.gitignore`

Note:
- Write `require 'byebug'; byebug` in a place where you want to debug.