### PR TITLE
T-2 Add `rspec` as dev dependency

### DIFF
--- a/basic_temperature.gemspec
+++ b/basic_temperature.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'byebug', '~> 11.1'
+  spec.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
- Setup [`rspec`](http://rspec.info/) as a development dependency.

Note:

- Run `bundle exec rspec` to execute all specs.