### PR TITLE
T-2 Initial Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 ---
 language: ruby
+
 cache: bundler
+
+before_install:
+  - yes | gem update --system --force
+  - gem install bundler -v 2.1.2
+
 rvm:
+  - 2.3.0
+  - 2.4.0
+  - 2.5.0
+  - 2.6.0
   - 2.7.0
-before_install: gem install bundler -v 2.1.2
+
+script: bundle exec rspec spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (11.1.1)
+    byebug (10.0.2)
     diff-lcs (1.3)
     rake (12.3.3)
     rspec (3.9.0)
@@ -28,7 +28,7 @@ PLATFORMS
 
 DEPENDENCIES
   basic_temperature!
-  byebug (~> 11.1)
+  byebug (~> 10.0)
   rake (~> 12.0)
   rspec (~> 3.0)
 

--- a/basic_temperature.gemspec
+++ b/basic_temperature.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Value object for basic temperature operations like conversions from Celcius to Fahrenhait or Kelvin etc.}
   spec.homepage      = "https://github.com/marian13/basic_temperature"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.0.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'byebug', '~> 11.1'
+  spec.add_development_dependency 'byebug', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
- Set initial Travis CI config ([`.travis.yml`](https://github.com/forgecrafted/finishing_moves/blob/master/.travis.yml) from [finishing_moves](https://github.com/forgecrafted/finishing_moves) was used a template)
- Configured Travis CI to use Bundler 2 ([More details](https://docs.travis-ci.com/user/languages/ruby/#bundler-20))
- Decreased `byebug` version to support Ruby 2.3
- Increased minimal required Ruby version to 2.3

Notes:
- [Link to Travis CI settings](https://travis-ci.com/marian13/basic_temperature/settings)
- [Link to Travis CI docs for Ruby projects](https://docs.travis-ci.com/user/languages/ruby/)

TODO:
- Should `Gemfile.lock` be submitted in the repo?
- Are those lines necessary in `Gemfile`?
```
gem "rake", "~> 12.0"
gem "rspec", "~> 3.0"
```