### PR TITLE
T-4 Initial Rubocop Setup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+AllCops:
+  Exclude:
+    - .git/**/*
+    - bin/**/*
+    - pkg/**/*
+    - spec/**/*
+    - vendor/bundle/**/*
+
+Layout/LineLength:
+  Max: 110
+
+Style/RedundantSelf:
+  Enabled: No

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ rvm:
   - 2.6.0
   - 2.7.0
 
-script: bundle exec rspec spec
+script:
+  - bundle exec rubocop
+  - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in basic_temperature.gemspec
 gemspec
-
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
     byebug (10.0.2)
     diff-lcs (1.3)
+    jaro_winkler (1.5.4)
+    parallel (1.19.1)
+    parser (2.7.0.3)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
     rake (12.3.3)
+    rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -22,6 +29,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
+    rubocop (0.80.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby
@@ -31,6 +48,7 @@ DEPENDENCIES
   byebug (~> 10.0)
   rake (~> 12.0)
   rspec (~> 3.0)
+  rubocop (~> 0.80.0)
 
 BUNDLED WITH
    2.1.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/basic_temperature.gemspec
+++ b/basic_temperature.gemspec
@@ -1,29 +1,39 @@
+# frozen_string_literal: true
+
 require_relative 'lib/basic_temperature/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "basic_temperature"
-  spec.version       = BasicTemperature::VERSION
-  spec.authors       = ["Marian Kostyk"]
-  spec.email         = ["mariankostyk13895@gmail.com"]
+  spec.name = 'basic_temperature'
+  spec.version = BasicTemperature::VERSION
 
-  spec.summary       = %q{Value object for basic temperature operations.}
-  spec.description   = %q{Value object for basic temperature operations like conversions from Celcius to Fahrenhait or Kelvin etc.}
-  spec.homepage      = "https://github.com/marian13/basic_temperature"
-  spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.authors = ['Marian Kostyk']
+  spec.email = ['mariankostyk13895@gmail.com']
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/CHANGELOG.md"
+  spec.summary = 'Value object for basic temperature operations.'
+  spec.description =
+    'Value object for basic temperature operations like ' \
+    'conversions from Celcius to Fahrenhait or Kelvin etc.'
+
+  spec.homepage = 'https://github.com/marian13/basic_temperature'
+
+  spec.license = 'MIT'
+
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['changelog_uri'] = "#{spec.homepage}/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
 
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_development_dependency 'byebug', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop', '~> 0.80.0'
 end

--- a/lib/basic_temperature/version.rb
+++ b/lib/basic_temperature/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BasicTemperature
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.0'
 end

--- a/spec/basic_temperature_spec.rb
+++ b/spec/basic_temperature_spec.rb
@@ -409,8 +409,8 @@ RSpec.describe BasicTemperature do
   end
 
   describe '#+' do
-    context 'when addend is a Numeric' do
-      it 'returns temperature, where degrees = self.degress + addend' do
+    context 'when other is a Numeric' do
+      it 'returns temperature, where degrees = self.degress + other' do
         temperature = BasicTemperature.new(0, 'celcius')
 
         new_temperature = temperature + 25
@@ -427,44 +427,44 @@ RSpec.describe BasicTemperature do
       end
     end
 
-    context 'when addend is a Temperature' do
-      it 'returns temperature, where degrees = self.degress + addend.degrees' do
+    context 'when other is a Temperature' do
+      it 'returns temperature, where degrees = self.degress + other.degrees' do
         temperature = BasicTemperature.new(0, 'celcius')
-        addend = BasicTemperature.new(30, 'celcius')
+        other = BasicTemperature.new(30, 'celcius')
 
-        new_temperature = temperature + addend
+        new_temperature = temperature + other
 
         expect(new_temperature.degrees).to eq(30)
       end
 
-      context 'and addend has different scale than temperature' do
-        it 'returns temperature, where degrees = self.to_scale(addend.scale).degress + addend.degrees' do
+      context 'and other has different scale than temperature' do
+        it 'returns temperature, where degrees = self.to_scale(other.scale).degress + other.degrees' do
           temperature = BasicTemperature.new(0, 'celcius')
-          addend = BasicTemperature.new(30, 'kelvin')
+          other = BasicTemperature.new(30, 'kelvin')
 
-          new_temperature = temperature + addend
+          new_temperature = temperature + other
 
-          expect(new_temperature.scale).to eq(addend.scale)
+          expect(new_temperature.scale).to eq(other.scale)
           expect(new_temperature.degrees).to eq(303.15)
         end
       end
     end
 
-    context 'when addend is neither Numeric nor Temperature' do
+    context 'when other is neither Numeric nor Temperature' do
       it 'raises CoersionError' do
         temperature = BasicTemperature.new(0, 'celcius')
-        addend = 'abc'
+        other = 'abc'
 
-        expect { new_temperature = temperature + addend }
-          .to raise_error(BasicTemperature::InvalidAddendError)
-          .with_message("`#{addend}` is neither Numeric nor Temperature.")
+        expect { new_temperature = temperature + other }
+          .to raise_error(BasicTemperature::InvalidOtherError)
+          .with_message("`#{other}` is neither Numeric nor Temperature.")
       end
     end
   end
 
   describe '#+' do
-    context 'when addend is a Numeric' do
-      it 'returns temperature, where degrees = self.degress + addend' do
+    context 'when other is a Numeric' do
+      it 'returns temperature, where degrees = self.degress + other' do
         temperature = BasicTemperature.new(0, 'celcius')
 
         new_temperature = temperature + 25
@@ -481,44 +481,44 @@ RSpec.describe BasicTemperature do
       end
     end
 
-    context 'when addend is a Temperature' do
-      it 'returns temperature, where degrees = self.degress + addend.degrees' do
+    context 'when other is a Temperature' do
+      it 'returns temperature, where degrees = self.degress + other.degrees' do
         temperature = BasicTemperature.new(0, 'celcius')
-        addend = BasicTemperature.new(30, 'celcius')
+        other = BasicTemperature.new(30, 'celcius')
 
-        new_temperature = temperature + addend
+        new_temperature = temperature + other
 
         expect(new_temperature.degrees).to eq(30)
       end
 
-      context 'and addend has different scale than temperature' do
-        it 'returns temperature, where degrees = self.to_scale(addend.scale).degress + addend.degrees' do
+      context 'and other has different scale than temperature' do
+        it 'returns temperature, where degrees = self.to_scale(other.scale).degress + other.degrees' do
           temperature = BasicTemperature.new(0, 'celcius')
-          addend = BasicTemperature.new(30, 'kelvin')
+          other = BasicTemperature.new(30, 'kelvin')
 
-          new_temperature = temperature + addend
+          new_temperature = temperature + other
 
-          expect(new_temperature.scale).to eq(addend.scale)
+          expect(new_temperature.scale).to eq(other.scale)
           expect(new_temperature.degrees).to eq(303.15)
         end
       end
     end
 
-    context 'when addend is neither Numeric nor Temperature' do
-      it 'raises InvalidAddendError' do
+    context 'when other is neither Numeric nor Temperature' do
+      it 'raises InvalidotherError' do
         temperature = BasicTemperature.new(0, 'celcius')
-        addend = 'abc'
+        other = 'abc'
 
-        expect { new_temperature = temperature + addend }
-          .to raise_error(BasicTemperature::InvalidAddendError)
-          .with_message("`#{addend}` is neither Numeric nor Temperature.")
+        expect { new_temperature = temperature + other }
+          .to raise_error(BasicTemperature::InvalidOtherError)
+          .with_message("`#{other}` is neither Numeric nor Temperature.")
       end
     end
   end
 
   describe '#-' do
-    context 'when subtrahend is a Numeric' do
-      it 'returns temperature, where degrees = self.degress - subtrahend' do
+    context 'when other is a Numeric' do
+      it 'returns temperature, where degrees = self.degress - other' do
         temperature = BasicTemperature.new(0, 'celcius')
 
         new_temperature = temperature - 25
@@ -535,37 +535,37 @@ RSpec.describe BasicTemperature do
       end
     end
 
-    context 'when subtrahend is a Temperature' do
-      it 'returns temperature, where degrees = self.degress - subtrahend.degrees' do
+    context 'when other is a Temperature' do
+      it 'returns temperature, where degrees = self.degress - other.degrees' do
         temperature = BasicTemperature.new(0, 'celcius')
-        subtrahend = BasicTemperature.new(30, 'celcius')
+        other = BasicTemperature.new(30, 'celcius')
 
-        new_temperature = temperature - subtrahend
+        new_temperature = temperature - other
 
         expect(new_temperature.degrees).to eq(-30)
       end
 
-      context 'and subtrahend has different scale than temperature' do
-        it 'returns temperature, where degrees = self.to_scale(subtrahend.scale).degress - subtrahend.degrees' do
+      context 'and other has different scale than temperature' do
+        it 'returns temperature, where degrees = self.to_scale(other.scale).degress - other.degrees' do
           temperature = BasicTemperature.new(0, 'celcius')
-          subtrahend = BasicTemperature.new(30, 'kelvin')
+          other = BasicTemperature.new(30, 'kelvin')
 
-          new_temperature = temperature - subtrahend
+          new_temperature = temperature - other
 
-          expect(new_temperature.scale).to eq(subtrahend.scale)
+          expect(new_temperature.scale).to eq(other.scale)
           expect(new_temperature.degrees).to eq(243.14999999999998)
         end
       end
     end
 
-    context 'when subtrahend is neither Numeric nor Temperature' do
-      it 'raises InvalidSubtrahendError' do
+    context 'when other is neither Numeric nor Temperature' do
+      it 'raises InvalidotherError' do
         temperature = BasicTemperature.new(0, 'celcius')
-        subtrahend = 'abc'
+        other = 'abc'
 
-        expect { new_temperature = temperature - subtrahend }
-          .to raise_error(BasicTemperature::InvalidAddendError)
-          .with_message("`#{subtrahend}` is neither Numeric nor Temperature.")
+        expect { new_temperature = temperature - other }
+          .to raise_error(BasicTemperature::InvalidOtherError)
+          .with_message("`#{other}` is neither Numeric nor Temperature.")
       end
     end
   end


### PR DESCRIPTION
- Added [`rubocop`](https://github.com/rubocop-hq/rubocop) as a dev dependency.
- Excluded the following folders in `.rubocop.yml`
```yml
 - .git/**/*
 - bin/**/*
 - pkg/**/*
 - spec/**/*
 - vendor/bundle/**/*
```
- Changed `Max` value of `Layout/LineLength` cop from `80` to `110`. 
- Disabled `Style/RedundantSelf` cop.
- Updated Travis CI to run [`rubocop`](https://github.com/rubocop-hq/rubocop).
- Fixed [`rubocop`](https://github.com/rubocop-hq/rubocop) in `Gemfile`, `Rakefile`, `basic_temperature.gemspec` and `lib` folder.
- Renamed `InvalidAddendError` to `InvalidOtherError`, `addend` to `other` and `subtrahend` to other.
- Removed from `Gemfile`
```ruby
gem "rake", "~> 12.0"
gem "rspec", "~> 3.0"
```
since they are listed as dev dependencies in `basic_temperature.gemspec`.