### PR TITLE
T-5 Setup coverage by SimpleCov and Coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,16 @@ GEM
   specs:
     ast (2.4.0)
     byebug (10.0.2)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
     diff-lcs (1.3)
+    docile (1.3.2)
     jaro_winkler (1.5.4)
+    json (2.3.0)
     parallel (1.19.1)
     parser (2.7.0.3)
       ast (~> 2.4.0)
@@ -38,6 +46,17 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.0.1)
+    tins (1.24.1)
+      sync
     unicode-display_width (1.6.1)
 
 PLATFORMS
@@ -46,9 +65,11 @@ PLATFORMS
 DEPENDENCIES
   basic_temperature!
   byebug (~> 10.0)
+  coveralls
   rake (~> 12.0)
   rspec (~> 3.0)
   rubocop (~> 0.80.0)
+  simplecov
 
 BUNDLED WITH
    2.1.2

--- a/basic_temperature.gemspec
+++ b/basic_temperature.gemspec
@@ -33,7 +33,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'byebug', '~> 10.0'
+  spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.80.0'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,0 +1,16 @@
+# DOCS: https://github.com/colszowka/simplecov
+# DOCS: https://docs.coveralls.io/ruby-on-rails
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+])
+
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
+# NOTE: `basic_temperature/version.rb` is ignored intentionally.
+# See https://github.com/colszowka/simplecov/issues/557

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require_relative 'coverage_helper'
+
 require "bundler/setup"
 require "basic_temperature"
 


### PR DESCRIPTION
- Added [`simplecov`](https://github.com/colszowka/simplecov) as a dev dependency.
- Added [`coveralls`](https://coveralls.io/) as a dev dependency.
- Created `coverage_gelper.rb` for `coverage` settings.
- Configured`coverage` to use both [`simplecov`](https://github.com/colszowka/simplecov) and [`coveralls`](https://coveralls.io/) formatters.

NOTE:
`basic_temperature/version.rb` is ignored from coverage intentionally.
See https://github.com/colszowka/simplecov/issues/557 and https://github.com/colszowka/simplecov/issues/557#issuecomment-410105995 for details.

