### PR TITLE
T-16 Code Climate Setup

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+# DOCS: https://docs.codeclimate.com/docs/advanced-configuration
+version: 2
+plugins:
+  rubocop:
+    enabled: true
+exclude_patterns:
+  - spec/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 ---
+# DOCS: https://docs.travis-ci.com/user/languages/ruby/#bundler-20
 language: ruby
 
 cache: bundler
 
 before_install:
+  # Bundler 2.0
   - yes | gem update --system --force
   - gem install bundler -v 2.1.2
 
@@ -15,5 +17,4 @@ rvm:
   - 2.7.0
 
 script:
-  - bundle exec rubocop
   - bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Build Status](https://travis-ci.com/marian13/basic_temperature.svg?branch=master)](https://travis-ci.com/marian13/basic_temperature)
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/a9acbc8db712f308d5f8/maintainability)](https://codeclimate.com/github/marian13/basic_temperature/maintainability)
+
+[![Coverage Status](https://coveralls.io/repos/github/marian13/basic_temperature/badge.svg)](https://coveralls.io/github/marian13/basic_temperature)
+
 # BasicTemperature
 
 Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/basic_temperature`. To experiment with that code, run `bin/console` for an interactive prompt.


### PR DESCRIPTION
- Configured initial `.codeclimate.yml` ([docs](https://docs.codeclimate.com/docs/advanced-configuration))
- Added `codeclimate` badge to README.md ([docs](https://codeclimate.com/github/marian13/basic_temperature/badges))
- Added `coveralls` badge to README.md ([docs](https://coveralls.io/github/marian13/basic_temperature/settings))
- Added `Travis CI` badge to README.md ([docs](https://docs.travis-ci.com/user/status-images/))

NOTE:
`coverage` can be automated by code climate too. But it is much easier to configure it when CI runs only one version of Ruby. 
