### PR TITLE
T-6 Setup reverse coverage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ GEM
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (12.3.3)
+    reverse_coverage (0.1.1)
+      rspec (~> 3.8)
     rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -67,6 +69,7 @@ DEPENDENCIES
   byebug (~> 10.0)
   coveralls
   rake (~> 12.0)
+  reverse_coverage
   rspec (~> 3.0)
   rubocop (~> 0.80.0)
   simplecov

--- a/basic_temperature.gemspec
+++ b/basic_temperature.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.80.0'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'reverse_coverage'
 end

--- a/spec/reverse_coverage_helper.rb
+++ b/spec/reverse_coverage_helper.rb
@@ -1,0 +1,21 @@
+require 'reverse_coverage'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    ReverseCoverage::Main.start
+  end
+
+  config.around do |e|
+    e.run
+
+    ReverseCoverage::Main.add(e)
+  end
+
+  config.after(:suite) do
+    ReverseCoverage::Main.save_results
+
+    coverage_matrix = ReverseCoverage::Main.coverage_matrix
+
+    ReverseCoverage::Formatters::HTML::Formatter.new.format(coverage_matrix)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,15 @@
-require_relative 'coverage_helper'
+if ENV['REVERSE_COVERAGE']
+  require_relative 'reverse_coverage_helper'
+else
+  require_relative 'coverage_helper'
+end
 
-require "bundler/setup"
-require "basic_temperature"
+require 'bundler/setup'
+require 'basic_temperature'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
- Added [`reverse_coverage`](https://github.com/nebulab/reverse_coverage) as a development dependency.

NOTE:
- To generate `coverage` results, run `bundle exec rspec` as always
- To generate `reverse_coverage` results, run `REVERSE_COVERAGE=true bundle exec rspec`.

NOTE:
`reverse_coverage_helper.rb` conflicts with `coverage_helper.rb`.

When you run them together you will see:
```ruby
coverage measurement is not enabled (RuntimeError)   
```
As a result, coverage and reverse coverage should not be executed together.

