### PR TITLE
T-15 Configure Travis CI to use bundler-audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ rvm:
 
 script:
   - bundle exec rspec
+  - bundle exec bundle-audit check --update


### PR DESCRIPTION
- Added [bundler-audit](https://github.com/rubysec/bundler-audit) to Travis CI config.

> Update the ruby-advisory-db and check Gemfile.lock (useful for CI runs):

```
$ bundle-audit check --update
```
 