### PR TITLE
T-15 Update coveralls to fix rest-client vulnerabilities

### DIFF
--- a/basic_temperature.gemspec
+++ b/basic_temperature.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler-audit'
   spec.add_development_dependency 'byebug', '~> 10.0'
-  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rerun'
   spec.add_development_dependency 'reverse_coverage'


### PR DESCRIPTION
- Updated `coveralls` to fix `rest-client` vulnerabilities (`rest-client` is a depdendency of `coveralls`).

How?

- Added specific version to `gemspec` for `coveralls`.
- Deleted `Gemfile.lock`.
- Executed `bundle install`.
