### PR TITLE
T-60 Temporarly disable Style/Documentation Warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ Style/AsciiComments:
 
 Style/Documentation:
   Severity: warning
+  Enabled: No
 
 Style/Lambda:
   EnforcedStyle: literal


### PR DESCRIPTION
- Temporarly disabled Style/Documentation Warning, because `bundle exec rubocop` returns only even if only warnings are found.