### PR TITLE
T-61 Add bundler-audit to Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,6 +2,8 @@
 version: 2
 
 plugins:
+  bundler-audit:
+    enabled: true
   rubocop:
     enabled: true
     channel: rubocop-0-80


### PR DESCRIPTION
- Added [bundler-audit](https://github.com/rubysec/bundler-audit) to Code Climate. See [https://docs.codeclimate.com/docs/bundler-audit](https://docs.codeclimate.com/docs/bundler-audit) for details.

**Notes:**
- It does nothing since repo does have Gemfile.lock,
but it can be useful later when this repo will be used as a template for other repos.
