### PR TITLE
T-60 Ignore docker/.DS_Store and add colons in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Ignore `Gemfile.lock`
 Gemfile.lock
+
+# Docker .DS_Store
+/docker/.DS_Store

--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/marian
 
 ## Development with Docker
 
-* Build container `docker build . -f docker/Dockerfile-2.3 -t basic_temperature_2.3`.
+* Build container: `docker build . -f docker/Dockerfile-2.3 -t basic_temperature_2.3`.
 
-* Run specs inside container `docker run -it basic_temperature_2.3:latest bundle exec rspec`.
+* Run specs inside container: `docker run -it basic_temperature_2.3:latest bundle exec rspec`.
 
-* Interactive shell inside container `docker run -it basic_temperature_2.3:latest bash`.
+* Interactive shell inside container: `docker run -it basic_temperature_2.3:latest bash`.
 
 * 2.3 can be replaced by 2.4, 2.5, 2.6 and 2.7.
 


### PR DESCRIPTION
- Added `docker/.DS_Store` to `.gitignore`.

- Added colons in README for docker commands.
