### PR TITLE
T-65: Disable bundle-audit by codeclimate because basic_temperature has no Gemfile.lock inside remote repo

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,8 +2,6 @@
 version: 2
 
 plugins:
-  bundler-audit:
-    enabled: true
   rubocop:
     enabled: true
     channel: rubocop-0-80


### PR DESCRIPTION
- Disabled `bundle-audit` by `Codeclimate` because `basic_temperature` has no `Gemfile.lock` inside remote repo.