### PR TITLE
T-79: Set up Coveralls using GitHub Actions

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@
 # NOTE: Virtual Environments.
 # - https://github.com/actions/virtual-environments
 #
+# NOTE: How to collect and upload coverage reports for Coveralls?
+# - https://github.com/marketplace/actions/coveralls-github-action#complete-parallel-job-example
+# - https://github.com/coverallsapp/github-action/issues/29
+# - https://github.com/coverallsapp/github-action/issues/29#issuecomment-704366557
+#
 # IMPORTANT: This workflow is heavily based on Shopify/packwerk workflow.
 # - https://github.com/Shopify/packwerk/blob/main/.github/workflows/ci.yml
 # - https://github.com/Shopify/packwerk/actions/runs/331834549/workflow
@@ -32,10 +37,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
 
 jobs:
   lint:
@@ -94,3 +99,22 @@ jobs:
           bundler-cache: true
       - name: Run RSpec
         run: bundle exec rspec
+      - name: Collect coverage reports for Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.ruby }}-${{ matrix.gemfile }}
+          parallel: true
+          path-to-lcov: "./coverage/lcov.info"
+
+  coverage:
+    name: Gather coverage
+    needs:
+      - test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Upload coverage reports to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/basic_temperature.gemspec
+++ b/basic_temperature.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler-audit'
   spec.add_development_dependency 'byebug', '~> 10.0'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rerun'
   spec.add_development_dependency 'reverse_coverage'
@@ -39,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.80.0'
   spec.add_development_dependency 'sdoc'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'simplecov-lcov'
 end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,16 +1,53 @@
-# DOCS: https://github.com/colszowka/simplecov
-# DOCS: https://docs.coveralls.io/ruby-on-rails
+##
+# Coverage using SimpleCov.
+#
+# NOTE: What is SimpleCov?
+# https://github.com/simplecov-ruby/simplecov
+#
+# NOTE: What is lcov and how to set up it?
+# - https://github.com/fortissimo1997/simplecov-lcov
+# - https://github.com/tagliala/coveralls-ruby-reborn#github-actions
+#
+# NOTE: How to deploy coverage data to Coveralls using GitHub Actions?
+# - https://github.com/marketplace/actions/coveralls-github-action
+# - https://github.com/coverallsapp/github-action/issues/29
+#
+# IMPORTANT: Why `basic_temperature/version.rb` is ignored? See:
+# https://github.com/simplecov-ruby/simplecov/issues/557
+#
+
+##
+# HACK: Fixes the following error for older Ruby versions.
+#
+#   Formatter SimpleCov::Formatter::LcovFormatter failed with NoMethodError: undefined method `branch_coverage?' for SimpleCov:Module
+#
+# https://github.com/fortissimo1997/simplecov-lcov/pull/25/files
+#
+# TODO: Remove when support for Rubies lower than 2.5 will be dropped.
+#
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
+  module SimpleCov
+    class << self
+      def branch_coverage?
+        false
+      end
+    end
+  end
+end
+
 require 'simplecov'
-require 'coveralls'
+require 'simplecov-lcov'
+
+SimpleCov::Formatter::LcovFormatter.config do |config|
+  config.report_with_single_file = true
+  config.single_report_path = 'coverage/lcov.info'
+end
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
+  SimpleCov::Formatter::LcovFormatter
 ])
 
 SimpleCov.start do
   add_filter '/spec/'
 end
-
-# NOTE: `basic_temperature/version.rb` is ignored intentionally.
-# See https://github.com/colszowka/simplecov/issues/557


### PR DESCRIPTION
- Set up Coveralls using GitHub Actions.
- Remove `coveralls` gem. [Why?](https://github.com/tagliala/coveralls-ruby-reborn#github-actions)
- Add `simplecov-lcov` gem (generic coverage format).
- Rename CI branch from `master` to `main`.