### PR TITLE
T-94: Code Climate does not support custom Rubocop config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,6 +2,10 @@
 # Code Climate configuration file.
 # https://docs.codeclimate.com/docs/advanced-configuration
 #
+# IMPORTANT: Code Climate does not support custom Rubocop config like Standard.rb.
+# That is why Code Climate badge shows failures all the time.
+# https://github.com/codeclimate/codeclimate-rubocop/issues/131
+#
 version: 2
 
 plugins:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,7 @@ require:
   #
   - rubocop-rspec
   ##
-  # An extension of RuboCop focused on code performance checks (required by Standard.rb).
-  # https://github.com/rubocop/rubocop-performance
-  # https://github.com/testdouble/standard/blob/main/standard.gemspec#L23
+  # NOTE: `rubocop-performance' is automatically bundled with Standard.
   #
   - rubocop-performance
   ##

--- a/basic_temperature.gemspec
+++ b/basic_temperature.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rerun"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "standard"
   spec.add_development_dependency "sdoc"


### PR DESCRIPTION
- Reverted https://github.com/marian13/basic_temperature/pull/90 since it is not a source of Code Climate failures.
- Left comment that [Code Climate does not support custom Rubocop config](https://github.com/codeclimate/codeclimate-rubocop/issues/131). 